### PR TITLE
Handle missing world in island config

### DIFF
--- a/functions/init/fn_setIslandParams.sqf
+++ b/functions/init/fn_setIslandParams.sqf
@@ -1,3 +1,3 @@
 #include "component.hpp"
 
-OTF_ISWOODLAND = ["isWoodland"] call otf_common_fnc_getIslandCfgValue;
+OTF_ISWOODLAND = ["isWoodland", true] call otf_common_fnc_getIslandCfgValue;

--- a/functions/setup/fn_setMapRespawnPos.sqf
+++ b/functions/setup/fn_setMapRespawnPos.sqf
@@ -2,8 +2,8 @@
 
 if (!isServer) exitWith {};
 
-_bluforpos = ["spawnPosBlu"] call otf_common_fnc_getIslandCfgValue;
-_opforpos = ["spawnPosOpf"] call otf_common_fnc_getIslandCfgValue;
+_bluforpos = ["spawnPosBlu",[0,0,0]] call otf_common_fnc_getIslandCfgValue;
+_opforpos = ["spawnPosOpf",[0,0,0]] call otf_common_fnc_getIslandCfgValue;
 
 _bluforpos = _bluforpos findEmptyPosition [0,20];
 _opforpos = _opforpos findEmptyPosition [0,20];


### PR DESCRIPTION
When the world is mission in grad-islandconfig a default value is returned by `getIslandCfgValue`, which is -1 by default, but we expect a bool.

I set the default to true, because I prefer playing with woodland camo on a desert map, instead of playing with desert camo in the forest. 